### PR TITLE
t_cose: Adapt this to use the mbedtls library from rust-psa-crypto.

### DIFF
--- a/Makefile.psa
+++ b/Makefile.psa
@@ -25,10 +25,7 @@ QCBOR_LIB= -L $(OUT_DIR) -l qcbor
 
 # ---- crypto configuration -----
 
-# These two are for reference to MBed Crypto that has been installed in
-# /usr/local/ or in some system location.
-CRYPTO_LIB=-L ../mbed-crypto/library -l mbedcrypto
-CRYPTO_INC=-I ../mbed-crypto/include
+CRYPTO_INC= -I ../../../third-party/rust-psa-crypto/psa-crypto-sys/vendor/include
 
 CRYPTO_CONFIG_OPTS=-DT_COSE_USE_PSA_CRYPTO
 CRYPTO_OBJ=$(OUT_DIR)/t_cose_psa_crypto.o

--- a/inc/t_cose/t_cose_sign1_verify.h
+++ b/inc/t_cose/t_cose_sign1_verify.h
@@ -157,10 +157,10 @@ struct t_cose_sign1_verify_ctx {
 enum t_cose_err_t
 t_cose_sign1_verify_load_public_key(uint8_t const *p_pubkey,
                                     size_t pubkey_size,
-                                    uint16_t *p_key_handle);
+                                    uint32_t *p_key_handle);
 
 enum t_cose_err_t
-t_cose_sign1_verify_delete_public_key(uint16_t *p_key_handle);
+t_cose_sign1_verify_delete_public_key(uint32_t *p_key_handle);
 
 /**
  * \brief Initialize for \c COSE_Sign1 message verification.
@@ -227,7 +227,7 @@ t_cose_sign1_set_verification_key(struct t_cose_sign1_verify_ctx *context,
                                   struct t_cose_key               verification_key);
 
 enum t_cose_err_t
-t_cose_sign1_get_verification_pubkey(uint16_t key_handle,
+t_cose_sign1_get_verification_pubkey(uint32_t key_handle,
                                      uint8_t *p_pubkey, size_t capacity, size_t *p_size); 
 
 /**

--- a/src/t_cose_crypto.h
+++ b/src/t_cose_crypto.h
@@ -221,13 +221,13 @@ t_cose_crypto_pub_key_sign(int32_t                cose_algorithm_id,
 enum t_cose_err_t
 t_cose_load_pubkey(uint8_t const *p_pubkey,
                    size_t pubkey_size,
-                   uint16_t *p_key_handle);
+                   uint32_t *p_key_handle);
 
 enum t_cose_err_t
-t_cose_delete_pubkey(uint16_t *p_key_handle);
+t_cose_delete_pubkey(uint32_t *p_key_handle);
 
 enum t_cose_err_t
-t_cose_get_pubkey(uint16_t key_handle, uint8_t *p_pubkey, size_t capactity, size_t *p_sizeey);
+t_cose_get_pubkey(uint32_t key_handle, uint8_t *p_pubkey, size_t capactity, size_t *p_sizeey);
 /**
  * \brief Perform public key signature verification. Part of the
  * t_cose crypto adaptation layer.

--- a/src/t_cose_sign1_verify.c
+++ b/src/t_cose_sign1_verify.c
@@ -80,21 +80,21 @@ Done:
 enum t_cose_err_t
 t_cose_sign1_verify_load_public_key(uint8_t const *p_pubkey,
                                     size_t pubkey_size,
-                                    uint16_t *p_key_handle)
+                                    uint32_t *p_key_handle)
 {
     enum t_cose_err_t ret_val = t_cose_load_pubkey(p_pubkey, pubkey_size, p_key_handle);
     return ret_val;
 }
 
 enum t_cose_err_t
-t_cose_sign1_verify_delete_public_key(uint16_t *p_key_handle)
+t_cose_sign1_verify_delete_public_key(uint32_t *p_key_handle)
 {
     enum t_cose_err_t ret_val = t_cose_delete_pubkey(p_key_handle);
     return ret_val;
 }
 
 enum t_cose_err_t
-t_cose_sign1_get_verification_pubkey(uint16_t key_handle,
+t_cose_sign1_get_verification_pubkey(uint32_t key_handle,
                                      uint8_t *p_pubkey, size_t capacity, size_t *p_size) {
     enum t_cose_err_t ret_val = t_cose_get_pubkey(key_handle, p_pubkey, capacity, p_size);
     return ret_val;


### PR DESCRIPTION
Makefile.psa contains a relative path that may need to be updated
as we reorganise the Veracruz tree for workspaces.

The other changes are due to the PSA Crypto API having changed a bit.
In particular, key handles are now uint32_t instead of uint16_t.